### PR TITLE
dmtxwrite: document new encodation default

### DIFF
--- a/dmtxwrite/dmtxwrite.c
+++ b/dmtxwrite/dmtxwrite.c
@@ -384,7 +384,7 @@ OPTIONS:\n"), programName, programName);
   -m, --margin=N              margin size (in pixels)\n"));
       fprintf(stderr, _("\
   -e, --encoding=[abcet8x]    primary encodation scheme\n\
-            a = ASCII [default]   b = Best optimized [beta]\n\
+            a = ASCII             b = Best optimized [default]\n\
             c = C40               e = EDIFACT\n\
             t = Text              8 = Base 256\n\
             x = X12\n"));

--- a/man/dmtxwrite.1
+++ b/man/dmtxwrite.1
@@ -24,9 +24,9 @@ Margin size in pixels.
 .TP
 \fB\-e\fP, \fB\-\-encoding\fP=[bfactxe8]
 Encodation scheme.
-   b = Best optimized   best possible optimization (beta)
+   b = Best optimized   best possible optimization [default]
    f = Fast optimized   basic optimization (not implemented)
-   a = ASCII  [default] ASCII standard & extended
+   a = ASCII            ASCII standard & extended
    c = C40              digits and uppercase
    t = Text             digits and lowercase
    x = X12              ANSI X12 EDI


### PR DESCRIPTION
Commit da5fec1 ("Changed default mode to optimize best") changed the
default encodation scheme from the previous default of "ASCII" to the
automatic optimizer. However, the output of --help and the manpage still
claim that ASCII is the default, which can cause confusion.

I guess that change also means that this mode is no longer considered
"beta".

Update the documentation accordingly.