### PR TITLE
dmtxwrite: allow zero-width margin

### DIFF
--- a/dmtxwrite/dmtxwrite.c
+++ b/dmtxwrite/dmtxwrite.c
@@ -196,7 +196,7 @@ HandleArgs(UserOptions *opt, int *argcp, char **argvp[])
             break;
          case 'm':
             err = StringToInt(&opt->marginSize, optarg, &ptr);
-            if(err != DmtxPass || opt->marginSize <= 0 || *ptr != '\0')
+            if(err != DmtxPass || opt->marginSize < 0 || *ptr != '\0')
                FatalError(EX_USAGE, _("Invalid margin size specified \"%s\""), optarg);
             break;
          case 'e':


### PR DESCRIPTION
The Data Matrix standard prescribes a quiet zone of one module size around the symbol. However, when generating a symbol, it is sometimes useful to be able to leave out the quiet zone since there might be an inherent margin created by the printing process (or similar).

dmtxwrite already allows specifying a margin size independently from the module size, including margins smaller than the module size. However, it currently still enforces a minimum margin parameter of 1 pixel, which is inconvenient in the above scenario.

Extend the parameter check to allow zero-width margins.