### PR TITLE
Fix using CFLAGS from pkg-config for libdmtx

### DIFF
--- a/dmtxquery/Makefile.am
+++ b/dmtxquery/Makefile.am
@@ -5,9 +5,11 @@ bin_PROGRAMS = dmtxquery
 noinst_PROGRAMS = dmtxquery.debug
 
 dmtxquery_SOURCES = dmtxquery.c dmtxquery.h ../common/dmtxutil.c ../common/dmtxutil.h
+dmtxquery_CFLAGS = $(DMTX_CFLAGS)
 dmtxquery_LDFLAGS = $(DMTX_LIBS)
 dmtxquery_LDADD = $(LIBOBJS)
 
 dmtxquery_debug_SOURCES = dmtxquery.c dmtxquery.h ../common/dmtxutil.c ../common/dmtxutil.h
+dmtxquery_debug_CFLAGS = $(DMTX_CFLAGS)
 dmtxquery_debug_LDFLAGS = -static $(DMTX_LIBS)
 dmtxquery_debug_LDADD = $(LIBOBJS)

--- a/dmtxwrite/Makefile.am
+++ b/dmtxwrite/Makefile.am
@@ -10,6 +10,6 @@ dmtxwrite_LDFLAGS = $(DMTX_LIBS) $(MAGICK_LIBS)
 dmtxwrite_LDADD = $(LIBOBJS)
 
 dmtxwrite_debug_SOURCES = dmtxwrite.c dmtxwrite.h ../common/dmtxutil.c ../common/dmtxutil.h
-dmtxwrite_debug_CFLAGS = $(DMTX_FLAGS) $(MAGICK_CFLAGS) -D_MAGICK_CONFIG_H
+dmtxwrite_debug_CFLAGS = $(DMTX_CFLAGS) $(MAGICK_CFLAGS) -D_MAGICK_CONFIG_H
 dmtxwrite_debug_LDFLAGS = -static $(DMTX_LIBS) $(MAGICK_LIBS)
 dmtxwrite_debug_LDADD = $(LIBOBJS)


### PR DESCRIPTION
When building against _libdmtx_ installed in a nonstandard location, the include `dmtx.h` is not found. This is for example the case when building on macOS with _libdmtx_ installed via Homebrew. The build already determines relevant flags via `pkg-config` but did not actually use them.