### PR TITLE
corners to stdout

### DIFF
--- a/dmtxread/dmtxread.c
+++ b/dmtxread/dmtxread.c
@@ -633,10 +633,10 @@ PrintStats(DmtxDecode *dec, DmtxRegion *reg, DmtxMessage *msg,
       fprintf(stderr, "%d:", imgPageIndex + 1);
 
    if(opt->corners == DmtxTrue) {
-      fprintf(stderr, "%d,%d:", (int)(p00.X + 0.5), height - 1 - (int)(p00.Y + 0.5));
-      fprintf(stderr, "%d,%d:", (int)(p10.X + 0.5), height - 1 - (int)(p10.Y + 0.5));
-      fprintf(stderr, "%d,%d:", (int)(p11.X + 0.5), height - 1 - (int)(p11.Y + 0.5));
-      fprintf(stderr, "%d,%d:", (int)(p01.X + 0.5), height - 1 - (int)(p01.Y + 0.5));
+      fprintf(stdout, "%d,%d:", (int)(p00.X + 0.5), height - 1 - (int)(p00.Y + 0.5));
+      fprintf(stdout, "%d,%d:", (int)(p10.X + 0.5), height - 1 - (int)(p10.Y + 0.5));
+      fprintf(stdout, "%d,%d:", (int)(p11.X + 0.5), height - 1 - (int)(p11.Y + 0.5));
+      fprintf(stdout, "%d,%d:", (int)(p01.X + 0.5), height - 1 - (int)(p01.Y + 0.5));
    }
 
    return DmtxPass;


### PR DESCRIPTION
As in old (at least 2007!) versions of dmtxread the corners positions are now returned via stdout (not stderr).
This is conform to the option --corners where positions are expected to prefix the message